### PR TITLE
Fix handling of unicode arguments on windows

### DIFF
--- a/src/gas/gas.cc
+++ b/src/gas/gas.cc
@@ -247,7 +247,8 @@ Gas::ParseArgsResult Gas::parse_arguments (int argc, char **argv, std::unique_pt
 				// Ignore the arch hack parameter
 				const char *ret = strstr (optarg, Constants::arch_hack_param);
 				if (ret == nullptr || ret != optarg) {
-					input_files.emplace_back (optarg);
+					// char8_t* cast treats path string as utf8
+					input_files.emplace_back ((char8_t*)optarg);
 				}
 			}
 			break;
@@ -267,7 +268,7 @@ Gas::ParseArgsResult Gas::parse_arguments (int argc, char **argv, std::unique_pt
 				break;
 
 			case OPTION_O:
-				_gas_output_file = optarg;
+				_gas_output_file = (char8_t*)optarg;
 				break;
 
 			case OPTION_MFPU:

--- a/src/gas/gas.cc
+++ b/src/gas/gas.cc
@@ -248,7 +248,7 @@ Gas::ParseArgsResult Gas::parse_arguments (int argc, char **argv, std::unique_pt
 				const char *ret = strstr (optarg, Constants::arch_hack_param);
 				if (ret == nullptr || ret != optarg) {
 					// char8_t* cast treats path string as utf8
-					input_files.emplace_back ((char8_t*)optarg);
+					input_files.emplace_back (reinterpret_cast<char8_t*>(optarg));
 				}
 			}
 			break;
@@ -268,7 +268,7 @@ Gas::ParseArgsResult Gas::parse_arguments (int argc, char **argv, std::unique_pt
 				break;
 
 			case OPTION_O:
-				_gas_output_file = (char8_t*)optarg;
+				_gas_output_file = reinterpret_cast<char8_t*>(optarg);
 				break;
 
 			case OPTION_MFPU:

--- a/src/gas/gas.hh
+++ b/src/gas/gas.hh
@@ -165,6 +165,8 @@ namespace xamarin::android::gas
 		~Gas ()
 		{}
 
+		void get_command_line (int &argc, char **&argv);
+
 		int run (int argc, char **argv);
 
 		const std::string& program_name () const noexcept

--- a/src/gas/gas.posix.cc
+++ b/src/gas/gas.posix.cc
@@ -6,6 +6,10 @@
 
 using namespace xamarin::android::gas;
 
+void Gas::get_command_line ([[maybe_unused]] int &argc, [[maybe_unused]] char **&argv)
+{
+}
+
 void Gas::determine_program_dir ([[maybe_unused]] int argc, char **argv)
 {
 	fs::path program_path { argv[0] };

--- a/src/gas/gas.windows.cc
+++ b/src/gas/gas.windows.cc
@@ -13,6 +13,20 @@
 
 using namespace xamarin::android::gas;
 
+void Gas::get_command_line (int &argc, char **&argv)
+{
+	LPWSTR *argvw = CommandLineToArgvW (GetCommandLineW (), &argc);
+	argv = new char*[argc + 1];
+
+	for (int i = 0; i < argc; i++) {
+		int size = WideCharToMultiByte (CP_UTF8, 0, argvw [i], -1, NULL, 0, NULL, NULL);
+		argv [i] = new char [size];
+		WideCharToMultiByte (CP_UTF8, 0, argvw [i], -1, argv [i], size, NULL, NULL);
+	}
+
+	argv [argc] = NULL;
+}
+
 void Gas::determine_program_dir ([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 {
 	TCHAR buffer[MAX_PATH + 1]{};

--- a/src/gas/main.cc
+++ b/src/gas/main.cc
@@ -5,6 +5,8 @@ xamarin::android::gas::Gas app;
 
 int main (int argc, char **argv)
 {
+	// On windows this obtains the utf8 version of args
+	app.get_command_line (argc, argv);
 	// TODO: handle exceptions here (use backward for stacktrace perhaps?)
 	return app.run (argc, argv);
 }

--- a/src/gas/process.windows.cc
+++ b/src/gas/process.windows.cc
@@ -84,8 +84,8 @@ int Process::run (bool print_command_line)
 		&pi
 	);
 
-	delete wargs;
-	delete wbinary;
+	delete[] wargs;
+	delete[] wbinary;
 
 	if (!success) {
 		return Constants::wrapper_exec_failed_error_code;

--- a/src/gas/process.windows.cc
+++ b/src/gas/process.windows.cc
@@ -58,14 +58,22 @@ int Process::run (bool print_command_line)
 		args.append (escape_argument (a));
 	}
 
+	int size =  MultiByteToWideChar (CP_UTF8, 0, args.c_str (), -1, NULL , 0);
+	wchar_t* wargs = new wchar_t [size];
+	MultiByteToWideChar (CP_UTF8, 0, args.c_str (), -1, wargs, size);
+
+	size =  MultiByteToWideChar (CP_UTF8, 0, binary.c_str (), -1, NULL , 0);
+	wchar_t* wbinary = new wchar_t [size];
+	MultiByteToWideChar (CP_UTF8, 0, binary.c_str (), -1, wbinary, size);
+
 	PROCESS_INFORMATION pi {};
-	STARTUPINFO si         {};
+	STARTUPINFOW si {};
 	si.cb = sizeof(si);
 
 	DWORD creation_flags = CREATE_UNICODE_ENVIRONMENT;
-	BOOL success = CreateProcess (
-		binary.c_str (),
-		const_cast<LPSTR>(args.c_str ()),
+	BOOL success = CreateProcessW (
+		wbinary,
+		wargs,
 		nullptr, // process security attributes
 		nullptr, // primary thread security attributes
 		TRUE, // inherit handles
@@ -75,6 +83,9 @@ int Process::run (bool print_command_line)
 		&si,
 		&pi
 	);
+
+	delete wargs;
+	delete wbinary;
 
 	if (!success) {
 		return Constants::wrapper_exec_failed_error_code;


### PR DESCRIPTION
This commit tweaks the `as.exe` tool to handle passing of file paths containing non ascii characters. This is done in the following steps:
- on windows, we don't use the `argc` and `argv` from main, since they only support ascii (unlike on linux where they contain utf8 directly). We use instead the windows api `CommandLineToArgvW` to get the arguments in utf16 and then convert it to utf8.
- when parsing the arguments and creating `std::filesystem::path`, we cast the `optarg` char* to the C++20 type char8_t* so the path constructor knows the string is in utf8 encoding.
- when creating the process, we convert the args from u8 to utf16 and use the wide char version of `CreateProcess`

This commit coupled with some mono aot fixes enables the compilation of a maui sample with special characters in project name. (https://github.com/dotnet/runtime/issues/83203)
