### PR TITLE
[ci] Migrate to the 1ES template

### DIFF
--- a/.gdn/.gdnsettings
+++ b/.gdn/.gdnsettings
@@ -1,0 +1,7 @@
+{
+  "files": { },
+  "folders": { },
+  "overwriteLogs": true,
+  "telemetryFlushTimeout": 10,
+  "variables": { }
+}

--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -1,0 +1,61 @@
+{
+  "hydrated": false,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/suppressions",
+    "hydrationStatus": "This file does not contain identifying data. It is safe to check into your repo. To hydrate this file with identifying data, run `guardian hydrate --help` and follow the guidance."
+  },
+  "version": "1.0.0",
+  "suppressionSets": {
+    "default": {
+      "name": "default",
+      "createdDate": "2024-02-15 00:04:36Z",
+      "lastUpdatedDate": "2024-02-15 00:04:36Z"
+    }
+  },
+  "results": {
+    "56abf01a2bb694a67c82be21f03a0dd66f296b49029f3c23bf6f3f82501cd2a3": {
+      "signature": "56abf01a2bb694a67c82be21f03a0dd66f296b49029f3c23bf6f3f82501cd2a3",
+      "alternativeSignatures": [
+        "be97b4284131d0f331716c30392a1e1d25474b8694363df3eea88a91d4152094"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unable to resolve BA2007 identified in external LLVM CMake configuration.",
+      "createdDate": "2024-02-15 00:04:36Z"
+    },
+    "5eceb0d6d6dba608d129867a6be091ad2bae06078aa8a057dfa67331c4b98772": {
+      "signature": "5eceb0d6d6dba608d129867a6be091ad2bae06078aa8a057dfa67331c4b98772",
+      "alternativeSignatures": [
+        "23dc4e92dd0ab3635230bd466fdde746fa0be745694ba8530eab31091dc375e8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unable to resolve BA2007 identified in external LLVM CMake configuration.",
+      "createdDate": "2024-02-15 00:04:36Z"
+    },
+    "fe61820f6936ba46368b182d5bbfc9576302c6c513803481bccdf0d863b966eb": {
+      "signature": "fe61820f6936ba46368b182d5bbfc9576302c6c513803481bccdf0d863b966eb",
+      "alternativeSignatures": [
+        "1868f8371a1ab6e1d82ab77b47a50f067e589870b4432ac45a2590876afd824e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unable to resolve BA2007 identified in external LLVM CMake configuration.",
+      "createdDate": "2024-02-15 00:04:36Z"
+    },
+    "fbf0466272fbf02d7b438d4adc1e193bc720677a220027755f5db357559a5777": {
+      "signature": "fbf0466272fbf02d7b438d4adc1e193bc720677a220027755f5db357559a5777",
+      "alternativeSignatures": [
+        "6da9f7a139b0c80204a3573e089aa0345b453280ac942cb59c224b7c6866af43"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unable to resolve BA2007 identified in external LLVM CMake configuration.",
+      "createdDate": "2024-02-15 00:04:36Z"
+    }
+  }
+}

--- a/.gdn/.gitignore
+++ b/.gdn/.gitignore
@@ -1,0 +1,11 @@
+﻿## Ignore Guardian internal files
+.r/
+rc/
+rs/
+i/
+p/
+c/
+o/
+
+## Ignore Guardian Local settings
+LocalSettings.gdn.json

--- a/build-llvm.cmd
+++ b/build-llvm.cmd
@@ -12,8 +12,9 @@ set PDBS=llvm-mc.pdb llvm-strip.pdb lld.pdb llc.pdb
 set HOST_BUILD_DIR=%BUILD_DIR%\%HOST%
 set HOST_BIN_DIR=%HOST_BUILD_DIR%\Release\bin
 set HOST_ARTIFACTS_DIR=%ARTIFACTS_DIR%\%HOST%
-set LLVM_VERSION_FILE=%HOST_ARTIFACTS_DIR%\llvm-version.txtt 
-set CXXFLAGS="/Qspectre /sdl"
+set LLVM_VERSION_FILE=%HOST_ARTIFACTS_DIR%\llvm-version.txt
+t 
+set CXXFLAGS="/Qspectre /sdl /guard:cf"
 
 if exist %HOST_BUILD_DIR% (rmdir /S /Q %HOST_BUILD_DIR%)
 mkdir %HOST_BUILD_DIR%
@@ -27,7 +28,7 @@ cmake --version
 cmake --help
 
 cmake -G "Visual Studio 17 2022" -A x64 ^
- -DCMAKE_EXE_LINKER_FLAGS_INIT="/PROFILE /DYNAMICBASE /CETCOMPAT" ^
+ -DCMAKE_EXE_LINKER_FLAGS_INIT="/PROFILE /DYNAMICBASE /CETCOMPAT /guard:cf" ^
  -DBUILD_SHARED_LIBS=OFF ^
  -DCMAKE_BUILD_TYPE=Release ^
  -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" ^
@@ -66,7 +67,7 @@ msbuild /p:Configuration=Release /m tools\lld\tools\lld\lld.vcxproj
 msbuild /p:Configuration=Release /m tools\llc\llc.vcxproj
 
 move %HOST_BIN_DIR%\llvm-objcopy.exe %HOST_BIN_DIR%\llvm-strip.exe
-move %HOST_BIN_DIR%\llvm-objcopy.pdb %HOST_BIN_DIR%\llvm-strip.pdb
+copy %HOST_BIN_DIR%\llvm-objcopy.pdb %HOST_BIN_DIR%\llvm-strip.pdb
 for %%b in (%BINARIES%) DO (
   copy %HOST_BIN_DIR%\%%b %HOST_ARTIFACTS_DIR%\bin\%%b
 )

--- a/build-llvm.cmd
+++ b/build-llvm.cmd
@@ -67,7 +67,7 @@ msbuild /p:Configuration=Release /m tools\lld\tools\lld\lld.vcxproj
 msbuild /p:Configuration=Release /m tools\llc\llc.vcxproj
 
 move %HOST_BIN_DIR%\llvm-objcopy.exe %HOST_BIN_DIR%\llvm-strip.exe
-copy %HOST_BIN_DIR%\llvm-objcopy.pdb %HOST_BIN_DIR%\llvm-strip.pdb
+move %HOST_BIN_DIR%\llvm-objcopy.pdb %HOST_BIN_DIR%\llvm-strip.pdb
 for %%b in (%BINARIES%) DO (
   copy %HOST_BIN_DIR%\%%b %HOST_ARTIFACTS_DIR%\bin\%%b
 )

--- a/build-llvm.cmd
+++ b/build-llvm.cmd
@@ -13,7 +13,6 @@ set HOST_BUILD_DIR=%BUILD_DIR%\%HOST%
 set HOST_BIN_DIR=%HOST_BUILD_DIR%\Release\bin
 set HOST_ARTIFACTS_DIR=%ARTIFACTS_DIR%\%HOST%
 set LLVM_VERSION_FILE=%HOST_ARTIFACTS_DIR%\llvm-version.txt
-t 
 set CXXFLAGS="/Qspectre /sdl /guard:cf"
 
 if exist %HOST_BUILD_DIR% (rmdir /S /Q %HOST_BUILD_DIR%)

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -28,13 +28,16 @@ variables:
   value: XamarinAndroid
 - name: BUILD_DIR
   value: xa-build
-- name: Codeql.Enabled
-  value: true
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  ${{ else }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
+      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        enableAllTools: false
       sourceAnalysisPool:
         name: AzurePipelines-EO
         image: AzurePipelinesWindows2022compliantGPT
@@ -142,6 +145,9 @@ extends:
         pool:
           name: AzurePipelines-EO
           image: AzurePipelinesWindows2022compliantGPT
+        variables:
+        - name: Codeql.Enabled
+          value: true
         templateContext:
           outputs:
           - output: pipelineArtifact

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -18,6 +18,10 @@ resources:
     name: xamarin/xamarin-android
     ref: refs/heads/main
     endpoint: xamarin
+  - repository: m365Pipelines
+    type: git
+    name: 1ESPipelineTemplates/M365GPT
+    ref: refs/tags/release
 
 variables:
 - name: TeamName

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -197,9 +197,9 @@ extends:
             displayName: Upload signing logs
             condition: succeededOrFailed()
             artifactName: sign-macos-binlog-$(System.JobAttempt)
-            targetPath: $(Build.StagingDirectory)/sign-macos.binlog
+            targetPath: $(Build.StagingDirectory)/binlogs/sign-macos.binlog
           - output: pipelineArtifact
-            displayName: 'Upload artifact'
+            displayName: Upload toolchain-signed artifact
             artifactName: android-llvm-toolchain-signed
             targetPath: $(Build.StagingDirectory)/toolchain
         steps:
@@ -237,7 +237,7 @@ extends:
             projects: build-tools/automation/sign.proj
             arguments: >-
               -p:SignType=$(MicroBuildSignType)
-              -bl:$(Build.StagingDirectory)/sign-macos.binlog
+              -bl:$(Build.StagingDirectory)/binlogs/sign-macos.binlog
 
         - template: build-tools/automation/yaml-templates/remove-microbuild-tooling.yaml@xa-yaml
           parameters:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -38,7 +38,7 @@ extends:
       sourceAnalysisPool:
         name: AzurePipelines-EO
         demands:
-        - ImageOverride -equals AzurePipelinesWindows2022compliant
+        - ImageOverride -equals AzurePipelinesWindows2022compliantGPT
     stages:
     - stage: build
       displayName: Build Stage
@@ -48,6 +48,7 @@ extends:
         timeoutInMinutes: 480
         pool:
           name: android-devdiv-ubuntu-vmss
+          os: linux
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -98,7 +99,8 @@ extends:
         timeoutInMinutes: 480
         pool:
           name: Azure Pipelines
-          vmImage: internal-macos12
+          vmImage: macOS-12
+          os: macOS
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -167,7 +169,8 @@ extends:
         timeoutInMinutes: 480
         pool:
           name: Azure Pipelines
-          vmImage: internal-macos12
+          vmImage: macOS-12
+          os: macOS
         templateContext:
           outputs:
           - output: pipelineArtifact

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -27,217 +27,219 @@ variables:
 - name: Codeql.Enabled
   value: true
 
-stages:
-- stage: build
-  displayName: Build Stage
-  jobs:
-  - job: build_linux
-    displayName: Build Linux
-    timeoutInMinutes: 240
-    pool:
-      name: android-devdiv-ubuntu-vmss
-    steps:
-    - checkout: self
-      submodules: recursive
+extends:
+  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        demands:
+        - ImageOverride -equals AzurePipelinesWindows2022compliant
+    stages:
+    - stage: build
+      displayName: Build Stage
+      jobs:
+      - job: build_linux
+        displayName: Build Linux
+        timeoutInMinutes: 480
+        pool:
+          name: android-devdiv-ubuntu-vmss
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Upload logs'
+            condition: always()
+            artifactName: build-logs-linux
+            targetPath: $(Build.StagingDirectory)
+          - output: pipelineArtifact
+            displayName: 'Upload artifacts'
+            artifactName: artifacts-linux-unsigned
+            targetPath: artifacts
+        steps:
+        - checkout: self
+          submodules: recursive
 
-    - script: >-
-        sudo apt-get update;
-        sudo apt-get -f -u install cmake ninja-build chrpath texinfo sharutils libffi-dev
-        lsb-release patchutils diffstat xz-utils python3-dev libedit-dev libncurses5-dev swig
-        python3-six python3-sphinx binutils-dev libxml2-dev libjsoncpp-dev pkg-config lcov
-        procps help2man zlib1g-dev g++-multilib libjs-mathjax python3-recommonmark libpfm4-dev
-        python3-setuptools libz3-dev ccache
-      displayName: Install LLVM build dependencies
+        - script: >-
+            sudo apt-get update;
+            sudo apt-get -f -u install cmake ninja-build chrpath texinfo sharutils libffi-dev
+            lsb-release patchutils diffstat xz-utils python3-dev libedit-dev libncurses5-dev swig
+            python3-six python3-sphinx binutils-dev libxml2-dev libjsoncpp-dev pkg-config lcov
+            procps help2man zlib1g-dev g++-multilib libjs-mathjax python3-recommonmark libpfm4-dev
+            python3-setuptools libz3-dev ccache
+          displayName: Install LLVM build dependencies
 
-    - script: sudo apt-get -f -u install mingw-w64 libz-mingw-w64-dev
-      displayName: Install Xamarin.Android Utilities build dependencies
+        - script: sudo apt-get -f -u install mingw-w64 libz-mingw-w64-dev
+          displayName: Install Xamarin.Android Utilities build dependencies
 
-    - script: ./build-llvm.sh
-      env:
-        CC: gcc-10
-        CXX: g++-10
-      displayName: Build LLVM
+        - script: ./build-llvm.sh
+          env:
+            CC: gcc-10
+            CXX: g++-10
+          displayName: Build LLVM
 
-    - script: ./build-xa-utils.sh
-      env:
-        CC: gcc-10
-        CXX: g++-10
-      displayName: Build utilities
+        - script: ./build-xa-utils.sh
+          env:
+            CC: gcc-10
+            CXX: g++-10
+          displayName: Build utilities
 
-    - script: |
-        rsync -avm --include 'config.*' --include '*.log' --include '*.txt' --include='*/' --exclude='*' $(BUILD_DIR) $(Build.StagingDirectory)
-      displayName: Copy logs
-      condition: always()
-
-    - task: PublishPipelineArtifact@1
-      displayName: Upload logs
-      inputs:
-        artifactName: build-logs-linux
-        targetPath: $(Build.StagingDirectory)
-      condition: always()
-
-    - task: PublishPipelineArtifact@1
-      displayName: Upload artifacts
-      inputs:
-        artifactName: artifacts-linux-unsigned
-        targetPath: artifacts
-
-
-  - job: build_macos
-    displayName: Build macOS
-    timeoutInMinutes: 240
-    pool:
-      name: Azure Pipelines
-      vmImage: internal-macos12
-    steps:
-    - checkout: self
-      submodules: recursive
-
-    - script: |
-        brew update
-        brew install cmake ninja ccache
-      displayName: Install LLVM build dependencies
-
-    - script: brew install make xz
-      displayName: Install Xamarin.Android Utilities build dependencies
-
-    - script: bash ./build-llvm.sh
-      displayName: build LLVM
-
-    - script: bash ./build-xa-utils.sh
-      displayName: Build utilities
-
-    - script: |
-        rsync -avm --include 'config.*' --include '*.log' --include '*.txt' --include='*/' --exclude='*' $(BUILD_DIR) $(Build.StagingDirectory)
-      displayName: Copy logs
-      condition: always()
-
-    - task: PublishPipelineArtifact@1
-      displayName: Upload logs
-      inputs:
-        artifactName: build-logs-macos
-        targetPath: $(Build.StagingDirectory)
-      condition: always()
-
-    - task: PublishPipelineArtifact@1
-      displayName: Upload artifacts
-      inputs:
-        artifactName: artifacts-macos-unsigned
-        targetPath: artifacts
+        - script: |
+            rsync -avm --include 'config.*' --include '*.log' --include '*.txt' --include='*/' --exclude='*' $(BUILD_DIR) $(Build.StagingDirectory)
+          displayName: Copy logs
+          condition: always()
 
 
-  - job: build_windows
-    displayName: Build Windows
-    timeoutInMinutes: 300
-    pool:
-      name: AzurePipelines-EO
-      demands:
-      - ImageOverride -equals AzurePipelinesWindows2022compliant
-    steps:
-    - checkout: self
-      submodules: recursive
+      - job: build_macos
+        displayName: Build macOS
+        timeoutInMinutes: 480
+        pool:
+          name: Azure Pipelines
+          vmImage: internal-macos12
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Upload logs'
+            condition: always()
+            artifactName: build-logs-macos
+            targetPath: $(Build.StagingDirectory)
+          - output: pipelineArtifact
+            displayName: 'Upload artifacts'
+            artifactName: artifacts-macos-unsigned
+            targetPath: artifacts
+        steps:
+        - checkout: self
+          submodules: recursive
 
-    - script: ./build-llvm-azure.cmd
-      displayName: Build Windows LLVM
+        - script: |
+            brew update
+            brew install cmake ninja ccache
+          displayName: Install LLVM build dependencies
 
-    - task: PublishPipelineArtifact@1
-      displayName: Upload artifacts
-      inputs:
-        artifactName: artifacts-windows-unsigned
-        targetPath: artifacts
+        - script: brew install make xz
+          displayName: Install Xamarin.Android Utilities build dependencies
 
+        - script: bash ./build-llvm.sh
+          displayName: build LLVM
 
-- stage: package
-  displayName: Package Stage
-  dependsOn: build
-  variables:
-  - name: MicroBuildSignType
-    value: Real
-  jobs:
-  - job: pack_sign
-    displayName: Sign and Zip
-    timeoutInMinutes: 240
-    pool:
-      name: Azure Pipelines
-      vmImage: internal-macos12
-    steps:
-    - checkout: self
-      submodules: recursive
+        - script: bash ./build-xa-utils.sh
+          displayName: Build utilities
 
-    - template: build-tools/automation/yaml-templates/install-microbuild-tooling.yaml@xa-yaml
-      parameters:
-        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: artifacts-linux-unsigned
-        downloadPath: artifacts
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: artifacts-macos-unsigned
-        downloadPath: artifacts
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: artifacts-windows-unsigned
-        downloadPath: artifacts
-
-    - task: CmdLine@2
-      inputs:
-        script: ./package.sh
-        workingDirectory: $(Build.SourcesDirectory)
-      displayName: Package artifacts
-
-    - task: DotNetCoreCLI@2
-      displayName: Sign and zip files
-      inputs:
-        projects: build-tools/automation/sign.proj
-        arguments: >-
-          -p:SignType=$(MicroBuildSignType)
-          -bl:$(Build.StagingDirectory)/sign-macos.binlog
-
-    - task: PublishPipelineArtifact@1
-      displayName: Upload artifact
-      inputs:
-        artifactName: sign-macos-binlog-$(System.JobAttempt)
-        targetPath: $(Build.StagingDirectory)/sign-macos.binlog
-      condition: always()
-
-    - template: build-tools/automation/yaml-templates/remove-microbuild-tooling.yaml@xa-yaml
-      parameters:
-        condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - script: >
-        mkdir -p $(Build.StagingDirectory)/toolchain &&
-        ln artifacts/android-llvm-toolchain*.zip $(Build.StagingDirectory)/toolchain
-      displayName: copy toolchain artifact
-
-    - task: PublishPipelineArtifact@1
-      displayName: Upload artifact
-      inputs:
-        artifactName: android-llvm-toolchain-signed
-        targetPath: $(Build.StagingDirectory)/toolchain
+        - script: |
+            rsync -avm --include 'config.*' --include '*.log' --include '*.txt' --include='*/' --exclude='*' $(BUILD_DIR) $(Build.StagingDirectory)
+          displayName: Copy logs
+          condition: always()
 
 
-  - job: sign_verify
-    displayName: Verify Signing
-    dependsOn: pack_sign
-    timeoutInMinutes: 240
-    pool:
-      name: VSEngSS-MicroBuild2022-1ES
-    steps:
-    - checkout: self
-      submodules: recursive
+      - job: build_windows
+        displayName: Build Windows
+        timeoutInMinutes: 600
+        pool:
+          name: AzurePipelines-EO
+          demands:
+          - ImageOverride -equals AzurePipelinesWindows2022compliant
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Upload artifacts'
+            artifactName: artifacts-windows-unsigned
+            targetPath: artifacts
+        steps:
+        - checkout: self
+          submodules: recursive
 
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: android-llvm-toolchain-signed
-        downloadPath: $(Build.SourcesDirectory)\artifacts
+        - script: ./build-llvm-azure.cmd
+          displayName: Build Windows LLVM
 
-    - task: MicroBuildCodesignVerify@3
-      displayName: verify signed content
-      inputs:
-        TargetFolders: $(Build.SourcesDirectory)\artifacts
-        ExcludeSNVerify: true
-      condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
+
+    - stage: package
+      displayName: Package Stage
+      dependsOn: build
+      variables:
+      - name: MicroBuildSignType
+        value: Real
+      jobs:
+      - job: pack_sign
+        displayName: Sign and Zip
+        timeoutInMinutes: 480
+        pool:
+          name: Azure Pipelines
+          vmImage: internal-macos12
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Upload artifact'
+            condition: always()
+            artifactName: sign-macos-binlog-$(System.JobAttempt)
+            targetPath: $(Build.StagingDirectory)/sign-macos.binlog
+          - output: pipelineArtifact
+            displayName: 'Upload artifact'
+            artifactName: android-llvm-toolchain-signed
+            targetPath: $(Build.StagingDirectory)/toolchain
+        steps:
+        - checkout: self
+          submodules: recursive
+
+        - template: build-tools/automation/yaml-templates/install-microbuild-tooling.yaml@xa-yaml
+          parameters:
+            condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: artifacts-linux-unsigned
+            downloadPath: artifacts
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: artifacts-macos-unsigned
+            downloadPath: artifacts
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: artifacts-windows-unsigned
+            downloadPath: artifacts
+
+        - task: CmdLine@2
+          inputs:
+            script: ./package.sh
+            workingDirectory: $(Build.SourcesDirectory)
+          displayName: Package artifacts
+
+        - task: DotNetCoreCLI@2
+          displayName: Sign and zip files
+          inputs:
+            projects: build-tools/automation/sign.proj
+            arguments: >-
+              -p:SignType=$(MicroBuildSignType)
+              -bl:$(Build.StagingDirectory)/sign-macos.binlog
+
+        - template: build-tools/automation/yaml-templates/remove-microbuild-tooling.yaml@xa-yaml
+          parameters:
+            condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
+
+        - script: >
+            mkdir -p $(Build.StagingDirectory)/toolchain &&
+            ln artifacts/android-llvm-toolchain*.zip $(Build.StagingDirectory)/toolchain
+          displayName: copy toolchain artifact
+
+
+      - job: sign_verify
+        displayName: Verify Signing
+        dependsOn: pack_sign
+        timeoutInMinutes: 240
+        pool:
+          name: VSEngSS-MicroBuild2022-1ES
+        steps:
+        - checkout: self
+          submodules: recursive
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: android-llvm-toolchain-signed
+            downloadPath: $(Build.SourcesDirectory)\artifacts
+
+        - task: MicroBuildCodesignVerify@3
+          displayName: verify signed content
+          inputs:
+            TargetFolders: $(Build.SourcesDirectory)\artifacts
+            ExcludeSNVerify: true
+          condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -29,15 +29,23 @@ variables:
 - name: BUILD_DIR
   value: xa-build
 
+parameters:
+- name: Skip1ESComplianceTasks
+  default: false
+
 extends:
-  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.Skip1ESComplianceTasks }}', 'true')) }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   ${{ else }}:
     template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      ${{ if eq('${{ parameters.Skip1ESComplianceTasks }}', 'true') }}:
         enableAllTools: false
+      codeql:
+        runSourceLanguagesInSourceAnalysis: true
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
       sourceAnalysisPool:
         name: AzurePipelines-EO
         image: AzurePipelinesWindows2022compliantGPT

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -32,7 +32,7 @@ variables:
   value: true
 
 extends:
-  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
       sourceAnalysisPool:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -28,6 +28,10 @@ variables:
   value: XamarinAndroid
 - name: BUILD_DIR
   value: xa-build
+- name: WindowsPoolImage1ESPT
+  value: 1ESPT-Windows2022
+- name: LinuxPoolImage1ESPT
+  value: 1ESPT-Ubuntu22.04
 
 parameters:
 - name: Skip1ESComplianceTasks
@@ -48,7 +52,8 @@ extends:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
       sourceAnalysisPool:
         name: AzurePipelines-EO
-        image: AzurePipelinesWindows2022compliantGPT
+        image: $(WindowsPoolImage1ESPT)
+        os: windows
     stages:
     - stage: build
       displayName: Build Stage
@@ -58,17 +63,17 @@ extends:
         timeoutInMinutes: 480
         pool:
           name: AzurePipelines-EO
-          image: AzurePipelinesUbuntu22.04compliantGPT
+          image: $(LinuxPoolImage1ESPT)
           os: linux
         templateContext:
           outputs:
           - output: pipelineArtifact
-            displayName: 'Upload logs'
+            displayName: Upload logs
             condition: always()
             artifactName: build-logs-linux
             targetPath: $(Build.StagingDirectory)
           - output: pipelineArtifact
-            displayName: 'Upload artifacts'
+            displayName: Upload linux-unsigned artifacts
             artifactName: artifacts-linux-unsigned
             targetPath: artifacts
         steps:
@@ -115,12 +120,12 @@ extends:
         templateContext:
           outputs:
           - output: pipelineArtifact
-            displayName: 'Upload logs'
+            displayName: Upload logs
             condition: always()
             artifactName: build-logs-macos
             targetPath: $(Build.StagingDirectory)
           - output: pipelineArtifact
-            displayName: 'Upload artifacts'
+            displayName: Upload macos-unsigned artifacts
             artifactName: artifacts-macos-unsigned
             targetPath: artifacts
         steps:
@@ -152,14 +157,15 @@ extends:
         timeoutInMinutes: 600
         pool:
           name: AzurePipelines-EO
-          image: AzurePipelinesWindows2022compliantGPT
+          image: $(WindowsPoolImage1ESPT)
+          os: windows
         variables:
         - name: Codeql.Enabled
           value: true
         templateContext:
           outputs:
           - output: pipelineArtifact
-            displayName: 'Upload artifacts'
+            displayName: Upload windows-unsigned artifacts
             artifactName: artifacts-windows-unsigned
             targetPath: artifacts
         steps:
@@ -185,10 +191,11 @@ extends:
           vmImage: macOS-12
           os: macOS
         templateContext:
+          outputParentDirectory: $(Build.StagingDirectory)
           outputs:
           - output: pipelineArtifact
-            displayName: 'Upload artifact'
-            condition: always()
+            displayName: Upload signing logs
+            condition: succeededOrFailed()
             artifactName: sign-macos-binlog-$(System.JobAttempt)
             targetPath: $(Build.StagingDirectory)/sign-macos.binlog
           - output: pipelineArtifact

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -37,8 +37,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: AzurePipelines-EO
-        demands:
-        - ImageOverride -equals AzurePipelinesWindows2022compliantGPT
+        image: AzurePipelinesWindows2022compliantGPT
     stages:
     - stage: build
       displayName: Build Stage
@@ -47,7 +46,8 @@ extends:
         displayName: Build Linux
         timeoutInMinutes: 480
         pool:
-          name: android-devdiv-ubuntu-vmss
+          name: AzurePipelines-EO
+          image: AzurePipelinesUbuntu22.04compliantGPT
           os: linux
         templateContext:
           outputs:
@@ -141,8 +141,7 @@ extends:
         timeoutInMinutes: 600
         pool:
           name: AzurePipelines-EO
-          demands:
-          - ImageOverride -equals AzurePipelinesWindows2022compliant
+          image: AzurePipelinesWindows2022compliantGPT
         templateContext:
           outputs:
           - output: pipelineArtifact

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -18,9 +18,9 @@ resources:
     name: xamarin/xamarin-android
     ref: refs/heads/main
     endpoint: xamarin
-  - repository: m365Pipelines
+  - repository: 1esPipelines
     type: git
-    name: 1ESPipelineTemplates/M365GPT
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
 variables:

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -72,6 +72,7 @@ extends:
             condition: always()
             artifactName: build-logs-linux
             targetPath: $(Build.StagingDirectory)
+            sbomEnabled: false
           - output: pipelineArtifact
             displayName: Upload linux-unsigned artifacts
             artifactName: artifacts-linux-unsigned
@@ -124,6 +125,7 @@ extends:
             condition: always()
             artifactName: build-logs-macos
             targetPath: $(Build.StagingDirectory)
+            sbomEnabled: false
           - output: pipelineArtifact
             displayName: Upload macos-unsigned artifacts
             artifactName: artifacts-macos-unsigned
@@ -198,6 +200,7 @@ extends:
             condition: succeededOrFailed()
             artifactName: sign-macos-binlog-$(System.JobAttempt)
             targetPath: $(Build.StagingDirectory)/binlogs/sign-macos.binlog
+            sbomEnabled: false
           - output: pipelineArtifact
             displayName: Upload toolchain-signed artifact
             artifactName: android-llvm-toolchain-signed


### PR DESCRIPTION
Context: https://aka.ms/1espt

The build pipeline has been updated to extend the 1ES pipeline template,
which will keep the pipeline up to date with the latest compliance and
security requirements.

Compliance tasks and scans will run automatically as part of artifact
upload steps, which are now referred to as "outputs".  Template outputs
have replaced all instances of the `PublishPipelineArtifact` task.

The new compliance steps appear to have added ~4 hours to the
build in the worst-case scenario (from 1.5 hours to 5.5 hours).  This
appears to mostly be a result of CodeQL.