### PR TITLE
[ci] Fix unsigned artifact uploading

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -159,7 +159,7 @@ extends:
             brew install cmake ninja ccache
           displayName: Install LLVM build dependencies
 
-        - script: brew install make xz
+        - script: export HOMEBREW_NO_INSTALL_UPGRADE=1 && brew install make xz
           displayName: Install Xamarin.Android Utilities build dependencies
 
         - script: bash ./build-llvm.sh

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -39,6 +39,11 @@ variables:
     value: Real
   ${{ else }}:
     value: Test
+- name: ToolchainArtifactName
+  ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.SignArtifactsOverride, 'true')) }}:
+    value: android-llvm-toolchain-signed
+  ${{ else }}:
+    value: android-llvm-toolchain-unsigned
 - name: TeamName
   value: XamarinAndroid
 - name: BUILD_DIR
@@ -214,8 +219,8 @@ extends:
             targetPath: $(Build.StagingDirectory)/binlogs/sign-macos.binlog
             sbomEnabled: false
           - output: pipelineArtifact
-            displayName: Upload toolchain-signed artifact
-            artifactName: android-llvm-toolchain-signed
+            displayName: Upload toolchain artifact
+            artifactName: $(ToolchainArtifactName)
             targetPath: $(Build.StagingDirectory)/toolchain
         steps:
         - checkout: self
@@ -251,6 +256,7 @@ extends:
           inputs:
             projects: build-tools/automation/sign.proj
             arguments: >-
+              -t:Build,ZipOutput
               -p:SignType=$(MicroBuildSignType)
               -bl:$(Build.StagingDirectory)/binlogs/sign-macos.binlog
 
@@ -276,7 +282,7 @@ extends:
 
         - task: DownloadPipelineArtifact@2
           inputs:
-            artifactName: android-llvm-toolchain-signed
+            artifactName: $(ToolchainArtifactName)
             downloadPath: $(Build.SourcesDirectory)\artifacts
 
         - task: MicroBuildCodesignVerify@3

--- a/build-tools/automation/sign.proj
+++ b/build-tools/automation/sign.proj
@@ -30,8 +30,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_ZipOutput"
-      AfterTargets="SignFiles" >
+  <Target Name="ZipOutput" >
     <ReadLinesFromFile File="$(OutDir)\darwin\llvm-version.txt" >
       <Output TaskParameter="Lines" ItemName="_VersionLines"/>
     </ReadLinesFromFile>


### PR DESCRIPTION
Commit de30a7e added conditions to skip signing on PR builds, but it
did not produce a valid toolchain artifact.  Fix this by updating the
zip task to always run and produce something to upload.