### PR TITLE
[ci] Don't upgrade installed brew dependencies

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -154,7 +154,7 @@ extends:
             brew install cmake ninja ccache
           displayName: Install LLVM build dependencies
 
-        - script: brew install make xz
+        - script: export HOMEBREW_NO_INSTALL_UPGRADE=1 && brew install make xz
           displayName: Install Xamarin.Android Utilities build dependencies
 
         - script: bash ./build-llvm.sh


### PR DESCRIPTION
Attempts to upgrade xz and its dependencies have been failing:

    ==> Pouring python@3.12--3.12.2_1.monterey.bottle.tar.gz
    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /usr/local
    Could not symlink bin/2to3
    Target /usr/local/bin/2to3
    already exists. You may want to remove it:
      rm '/usr/local/bin/2to3'

Attempt to fix this by skipping brew upgrades if they are already installed.