### PR TITLE
[ci] Build on performance build pools

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -82,7 +82,7 @@ extends:
         displayName: Build Linux
         timeoutInMinutes: 480
         pool:
-          name: AzurePipelines-EO
+          name: MAUI-1ESPT
           image: $(LinuxPoolImage1ESPT)
           os: linux
         templateContext:
@@ -135,8 +135,11 @@ extends:
         displayName: Build macOS
         timeoutInMinutes: 480
         pool:
-          name: Azure Pipelines
-          vmImage: macOS-12
+          ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+            name: Azure Pipelines
+            vmImage: macOS-latest
+          ${{ else }}:
+            name: VSEng-Xamarin-RedmondMac-Android-Untrusted
           os: macOS
         templateContext:
           outputs:
@@ -178,7 +181,7 @@ extends:
         displayName: Build Windows
         timeoutInMinutes: 600
         pool:
-          name: AzurePipelines-EO
+          name: MAUI-1ESPT
           image: $(WindowsPoolImage1ESPT)
           os: windows
         variables:
@@ -207,7 +210,7 @@ extends:
         timeoutInMinutes: 480
         pool:
           name: Azure Pipelines
-          vmImage: macOS-12
+          vmImage: macOS-latest
           os: macOS
         templateContext:
           outputParentDirectory: $(Build.StagingDirectory)

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -159,7 +159,7 @@ extends:
 
         - script: |
             brew update
-            brew install cmake ninja ccache
+            export HOMEBREW_NO_INSTALL_UPGRADE=1 && brew install cmake ninja ccache
           displayName: Install LLVM build dependencies
 
         - script: export HOMEBREW_NO_INSTALL_UPGRADE=1 && brew install make xz

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -135,7 +135,7 @@ extends:
         displayName: Build macOS
         timeoutInMinutes: 480
         pool:
-          ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+          ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.SignArtifactsOverride, 'true')) }}:
             name: Azure Pipelines
             vmImage: macOS-latest
           ${{ else }}:


### PR DESCRIPTION
The Windows and Linux builds have been updated to use a new pool with
a better VM SKU that has more CPU cores.  PR builds on macOS will also
use a static machine pool with better performance.