### PR TITLE
[ci] Disable automatic GitHub action trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,7 @@ env:
   BUILD_DIR: xa-build
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   build_llvm_linux:


### PR DESCRIPTION
We've migrated to an azure pipeline build in DevDiv for official builds,
and no longer need to run the GitHub action on every push/PR.