### PR TITLE
Bumped LLVM to v18.1.2 and XA utils version to 8.0.0

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-XA_UTILS_VERSION="5.0.0"
+XA_UTILS_VERSION="6.0.0"
 MACOS_TARGET="10.15"
 
 if [ -z "${MY_DIR}" ]; then

--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-XA_UTILS_VERSION="6.0.0"
+XA_UTILS_VERSION="8.0.0"
 MACOS_TARGET="10.15"
 
 if [ -z "${MY_DIR}" ]; then

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -6,8 +6,7 @@ MY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source common.sh
 
 WORK_DIR="${MY_DIR}/prep"
-ARTIFACT_TARBALL="${DIST_PACKAGE_NAME_BASE}.tar.bz2"
-ARTIFACTS_DIR="${WORK_DIR}/artifacts"
+ARTIFACTS_DIR="${WORK_DIR}"
 
 ARTIFACT_ZIP="${1}"
 XA_TAG_COMPONENT="${2}"
@@ -38,12 +37,6 @@ function prepare()
 	echo Unpacking artifact ZIP
 	unzip "${ARTIFACT_ZIP}"
 
-	if [ ! -f "${ARTIFACT_TARBALL}" ]; then
-		die Build artifact tarball $(pwd)/${ARTIFACT_TARBALL} not found
-	fi
-
-	echo Unpacking binaries tarball
-	tar xf "${ARTIFACT_TARBALL}"
 	if [ ! -d "${ARTIFACTS_DIR}" ]; then
 		die Artifacts directory ${ARTIFACTS_DIR} does not exist
 	fi


### PR DESCRIPTION
Changes: https://discourse.llvm.org/t/llvm-18-1-0-released/77448
Changes: https://discourse.llvm.org/t/llvm-18-1-1-released/77540
Changes: https://discourse.llvm.org/t/18-1-2-released/77821

Changes interesting for us:

  * AArch64 backend
    * Added support for Cortex-A520, Cortex-A720 and Cortex-X4 CPUs.
    * Assembler/disassembler support has been added for 2023 architecture extensions.
    * Support has been added for Stack Clash Protection. During function frame creation
      and dynamic stack allocations, the compiler will issue memory accesses at regular
      intervals so that a guard area at the top of the stack can’t be skipped over.
  * x86 backend
    * The i128 type now matches GCC and clang’s __int128 type. This mainly benefits external
      projects such as Rust which aim to be binary compatible with C, but also fixes code
      generation where LLVM already assumed that the type matched and called into libgcc
      helper functions.