### PR TITLE
Partially revert 9d342d5057

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -107,6 +107,7 @@ function prepare()
 		else
 			cp -P -a "${artifacts_source_bin}/${b}" "${artifacts_dest_bin}/${dest_b}"
 		fi
+		chmod 755 "${artifacts_dest_bin}/${dest_b}"
 
 		if [ -n "${src_pdb}" -a -f "${artifacts_source_bin}/${src_pdb}" ]; then
 			cp -P -a "${artifacts_source_bin}/${src_pdb}" "${artifacts_dest_bin}/${dest_pdb}"

--- a/src/compat-include/getopt.h
+++ b/src/compat-include/getopt.h
@@ -1,0 +1,97 @@
+#ifndef __GETOPT_H__
+/**
+ * DISCLAIMER
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ *
+ * The mingw-w64 runtime package and its code is distributed in the hope that it 
+ * will be useful but WITHOUT ANY WARRANTY.  ALL WARRANTIES, EXPRESSED OR 
+ * IMPLIED ARE HEREBY DISCLAIMED.  This includes but is not limited to 
+ * warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#define __GETOPT_H__
+
+/* All the headers include this file. */
+#include <crtdefs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int optind;		/* index of first non-option in argv      */
+extern int optopt;		/* single option character, as parsed     */
+extern int opterr;		/* flag to enable built-in diagnostics... */
+				/* (user may set to zero, to suppress)    */
+
+extern char *optarg;		/* pointer to argument of current option  */
+
+extern int getopt(int nargc, char * const *nargv, const char *options);
+
+#ifdef __cplusplus
+}
+#endif
+/*
+ * POSIX requires the `getopt' API to be specified in `unistd.h';
+ * thus, `unistd.h' includes this header.  However, we do not want
+ * to expose the `getopt_long' or `getopt_long_only' APIs, when
+ * included in this manner.  Thus, close the standard __GETOPT_H__
+ * declarations block, and open an additional __GETOPT_LONG_H__
+ * specific block, only when *not* __UNISTD_H_SOURCED__, in which
+ * to declare the extended API.
+ */
+#endif /* !defined(__GETOPT_H__) */
+
+#if !defined(__GETOPT_BSD_H__) && defined(_BSD_SOURCE)
+#define __GETOPT_BSD_H__
+/*
+ * BSD adds the non-standard `optreset' feature, for reinitialisation
+ * of `getopt' parsing.  We support this feature, for applications which
+ * proclaim their BSD heritage, before including this header; however,
+ * to maintain portability, developers are advised to avoid it.
+ */
+# define optreset  __mingw_optreset
+extern int optreset;
+#endif /* !defined(__GETOPT_BSD_H__) && defined(_BSD_SOURCE) */
+
+#if !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__)
+#define __GETOPT_LONG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct option		/* specification for a long form option...	*/
+{
+  const char *name;		/* option name, without leading hyphens */
+  int         has_arg;		/* does it take an argument?		*/
+  int        *flag;		/* where to save its status, or NULL	*/
+  int         val;		/* its associated status value		*/
+};
+
+enum    		/* permitted values for its `has_arg' field...	*/
+{
+  no_argument = 0,      	/* option never takes an argument	*/
+  required_argument,		/* option always requires an argument	*/
+  optional_argument		/* option may take an argument		*/
+};
+
+extern int getopt_long(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx);
+extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx);
+/*
+ * Previous MinGW implementation had...
+ */
+#ifndef HAVE_DECL_GETOPT
+/*
+ * ...for the long form API only; keep this for compatibility.
+ */
+# define HAVE_DECL_GETOPT	1
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__) */

--- a/src/compat/getopt.c
+++ b/src/compat/getopt.c
@@ -1,0 +1,562 @@
+/*	$OpenBSD: getopt_long.c,v 1.23 2007/10/31 12:34:57 chl Exp $	*/
+/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+
+/*
+ * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <windows.h>
+
+#define	REPLACE_GETOPT		/* use this getopt as the system getopt(3) */
+
+#ifdef REPLACE_GETOPT
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';		/* character checked for validity */
+#undef	optreset		/* see getopt.h */
+#define	optreset		__mingw_optreset
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+#endif
+
+#define PRINT_ERROR	((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
+#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+
+/* return values */
+#define	BADCH		(int)'?'
+#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
+#define	INORDER 	(int)1
+
+#ifndef __CYGWIN__
+#define __progname __argv[0]
+#else
+extern char __declspec(dllimport) *__progname;
+#endif
+
+#ifdef __CYGWIN__
+static char EMSG[] = "";
+#else
+#define	EMSG		""
+#endif
+
+static int getopt_internal(int, char * const *, const char *,
+			   const struct option *, int *, int);
+static int parse_long_options(char * const *, const char *,
+			      const struct option *, int *, int);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+static void
+_vwarnx(const char *fmt,va_list ap)
+{
+  (void)fprintf(stderr,"%s: ",__progname);
+  if (fmt != NULL)
+    (void)vfprintf(stderr,fmt,ap);
+  (void)fprintf(stderr,"\n");
+}
+
+static void
+warnx(const char *fmt,...)
+{
+  va_list ap;
+  va_start(ap,fmt);
+  _vwarnx(fmt,ap);
+  va_end(ap);
+}
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end,
+	char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * parse_long_options --
+ *	Parse long options in argc/argv argument vector.
+ * Returns -1 if short_too is set and the option does not match long_options.
+ */
+static int
+parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too)
+{
+	char *current_argv, *has_equal;
+	size_t current_argv_len;
+	int i, ambiguous, match;
+
+#define IDENTICAL_INTERPRETATION(_x, _y)                                \
+	(long_options[(_x)].has_arg == long_options[(_y)].has_arg &&    \
+	 long_options[(_x)].flag == long_options[(_y)].flag &&          \
+	 long_options[(_x)].val == long_options[(_y)].val)
+
+	current_argv = place;
+	match = -1;
+	ambiguous = 0;
+
+	optind++;
+
+	if ((has_equal = strchr(current_argv, '=')) != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = has_equal - current_argv;
+		has_equal++;
+	} else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name,
+		    current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			ambiguous = 0;
+			break;
+		}
+		/*
+		 * If this is a known short option, don't allow
+		 * a partial match of a single character.
+		 */
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1)	/* partial match */
+			match = i;
+		else if (!IDENTICAL_INTERPRETATION(i, match))
+			ambiguous = 1;
+	}
+	if (ambiguous) {
+		/* ambiguous abbreviation */
+		if (PRINT_ERROR)
+			warnx(ambig, (int)current_argv_len,
+			     current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (match != -1) {		/* option found */
+		if (long_options[match].has_arg == no_argument
+		    && has_equal) {
+			if (PRINT_ERROR)
+				warnx(noarg, (int)current_argv_len,
+				     current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			return (BADARG);
+		}
+		if (long_options[match].has_arg == required_argument ||
+		    long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg ==
+			    required_argument) {
+				/*
+				 * optional argument doesn't use next nargv
+				 */
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument)
+		    && (optarg == NULL)) {
+			/*
+			 * Missing argument; leading ':' indicates no error
+			 * should be generated.
+			 */
+			if (PRINT_ERROR)
+				warnx(recargstring,
+				    current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	} else {			/* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			warnx(illoptstring, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	} else
+		return (long_options[match].val);
+#undef IDENTICAL_INTERPRETATION
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ */
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags)
+{
+	char *oli;				/* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
+	 * XXX using optreset.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = optreset = 1;
+
+	/*
+	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
+	 * string begins with a '+'.
+	 *
+	 * CV, 2009-12-14: Check POSIXLY_CORRECT anew if optind == 0 or
+	 *                 optreset != 0 for GNU compatibility.
+	 */
+	if (posixly_correct == -1 || optreset != 0)
+		posixly_correct = (GetEnvironmentVariableW(L"POSIXLY_CORRECT", NULL, 0) != 0);
+	if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	else if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		if (*(place = nargv[optind]) != '-' ||
+		    (place[1] == '\0' && strchr(options, '-') == NULL)) {
+			place = EMSG;		/* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				 * If no permutation wanted, stop parsing
+				 * at first non-option.
+				 */
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		 * If we have "-" do nothing, if "--" we are done.
+		 */
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	 * Check long options if:
+	 *  1) we were passed some
+	 *  2) the arg is not just "-"
+	 *  3) either the arg starts with -- we are getopt_long_only()
+	 */
+	if (long_options != NULL && place != nargv[optind] &&
+	    (*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+		if (*place == '-')
+			place++;		/* --foo long option */
+		else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1;		/* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, short_too);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (optchar == (int)'-' && *place != '\0') ||
+	    (oli = strchr(options, optchar)) == NULL) {
+		/*
+		 * If the user specified "-" and  '-' isn't listed in
+		 * options, return -1 (non-option) as per POSIX.
+		 * Otherwise, it is an unknown option character (or ':').
+		 */
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place)			/* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		} else				/* white space */
+			place = nargv[optind];
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, 0);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the BSD getopt]
+ */
+int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+
+	/*
+	 * We don't pass FLAG_PERMUTE to getopt_internal() since
+	 * the BSD getopt(3) (unlike GNU) has never done this.
+	 *
+	 * Furthermore, since many privileged programs call getopt()
+	 * before dropping privileges it makes sense to keep things
+	 * as simple (and bug-free) as possible.
+	 */
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+#endif /* REPLACE_GETOPT */
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE));
+}
+
+/*
+ * getopt_long_only --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long_only(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE|FLAG_LONGONLY));
+}

--- a/src/gas/CMakeLists.txt
+++ b/src/gas/CMakeLists.txt
@@ -18,6 +18,7 @@ set(ARCH_PREFIXES
 
 if(WIN32)
   list(APPEND GAS_DRIVER_SOURCES
+    ../compat/getopt.c
     gas.windows.cc
     process.windows.cc
     )
@@ -33,10 +34,13 @@ add_executable(
   ${GAS_DRIVER_SOURCES}
   )
 
-# SYSTEM disables warnings produced by cxxopts headers, which we can do nothing about
-target_include_directories(as SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/../external/cxxopts/include)
-
 if(WIN32)
+  target_include_directories(
+    as
+    PRIVATE
+    ../compat-include
+  )
+
   target_link_libraries(
     as
     shlwapi

--- a/src/gas/gas.cc
+++ b/src/gas/gas.cc
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
-#include <cstring>
-#include <filesystem>
-#include <iostream>
+#if !defined (_WIN32)
+#include <unistd.h>
+#endif
 
-#include <cxxopts.hpp>
+#include <cstring>
+#include <iostream>
+#include <filesystem>
 
 #include "constants.hh"
 #include "gas.hh"
@@ -11,63 +13,12 @@
 
 using namespace xamarin::android::gas;
 
-cxxopts::Options Gas::create_options ()
-{
-	cxxopts::Options options (program_name(), PROGRAM_DESCRIPTION.data ());
-	options
-		.positional_help ("[asmfile...]")
-		.set_width (80);
-
-	options.add_options ("Supported GAS arguments")
-		("o",           "name the object-file output `arg` (default a.out)", cxxopts::value<std::string>())
-		("warn",        "don't suppress warnings", cxxopts::value<bool>())
-		("g,gen-debug", "generate debugging information", cxxopts::value<bool>())
-		("asmfile",     "assembler source file(s)", cxxopts::value<std::vector<std::string>>());
-
-	options.add_options ("Wrapper options, not passed to `llvm-mc`")
-		("h,help", "show this help screen", cxxopts::value<bool>())
-		("V", "show version", cxxopts::value<bool>())
-		("version", "show version and exit", cxxopts::value<bool>());
-
-	options.add_options ("Ignored by GAS and this wrapper")
-		("divide", "ignored", cxxopts::value<bool>())
-		("k", "ignored", cxxopts::value<bool>())
-		("nocpp", "ignored", cxxopts::value<bool>())
-		("Qn", "ignored", cxxopts::value<bool>())
-		("Qy", "ignored", cxxopts::value<bool>())
-		("s", "ignored", cxxopts::value<bool>())
-		("w", "ignored", cxxopts::value<bool>())
-		("X", "ignored", cxxopts::value<bool>());
-
-	switch (target_arch ()) {
-		case TargetArchitecture::ARM32:
-			options.add_options ("Arm options")
-				("mfpu", "assemble for FPU architecture <fpu name>", cxxopts::value<std::string>());
-			break;
-
-		case TargetArchitecture::X86:
-		case TargetArchitecture::X64:
-			options.add_options ("x86/x64 options")
-				("32", "generate 32bit object", cxxopts::value<bool>())
-				("64", "generate 64bit object", cxxopts::value<bool>());
-			break;
-
-		default:
-			break;
-	}
-
-	return options;
-}
-
 int Gas::usage (bool is_error, std::string const message)
 {
 	if (!message.empty ()) {
 		std::cerr << message << Constants::newline << Constants::newline;
 	}
 
-	cxxopts::Options options = create_options ();
-
-	std::cerr << options.help () << std::endl << std::endl;
 	std::cerr << "`" << program_name () << "` takes a subset of arguments accepted by the GNU Assembler (gas) program." << Constants::newline
 	          << "Accepted options are limited to the ones used by Xamarin.Android and Mono/dotnet AOT, more can be added as-needed." << Constants::newline
 	          << "Some options are accepted but ignored, either because they are ignored by GAS as well or because they are used by" << Constants::newline
@@ -76,7 +27,31 @@ int Gas::usage (bool is_error, std::string const message)
 	          << "Since `llvm-mc` does not support compiling multiple source files at the same time, this GAS behavior is emulated" << Constants::newline
 	          << "by running `llvm-mc` once per each input file and using the `ld` linker in the end to merge all the discrete output" << Constants::newline
 	          << "files into the single file indicated by the `-o` option." << Constants::newline << Constants::newline
-	          << "Command line options are compatibile with GAS version " << BINUTILS_VERSION << Constants::newline << Constants::newline;
+	          << "Command line options are compatibile with GAS version " << BINUTILS_VERSION << Constants::newline << Constants::newline
+	          << "Currently supported options are:" << Constants::newline << Constants::newline
+	          << "All targets" << Constants::newline
+	          << "   -o FILE            path to the output object file" << Constants::newline
+	          << "  --warn              don't suppress warning messages" << Constants::newline
+	          << "   -g | --gen-debug   generate debug information in the output object file" << Constants::newline << Constants::newline
+	          << "x86/x86_64 targets" << Constants::newline
+	          << "  --32                output a 32-bit object [ignored, `llvm-mc` is always invoked for the right target]" << Constants::newline
+	          << "  --64                output a 64-bit object [ignored, as above]" << Constants::newline << Constants::newline
+	          << "armeabi/arm32 targets" << Constants::newline
+	          << "  -mfpu=FPU           select floating-point architecture for the target" << Constants::newline << Constants::newline
+	          << "Ignored by GAS and this wrapper" << Constants::newline
+	          << "  --divide" << Constants::newline
+	          << "   -k" << Constants::newline
+	          << "  --nocpp" << Constants::newline
+	          << "   -Qn" << Constants::newline
+	          << "   -Qy" << Constants::newline
+	          << "   -s" << Constants::newline
+	          << "   -w" << Constants::newline
+	          << "   -X" << Constants::newline << Constants::newline
+	          << "Wrapper options, not passed to `llvm-mc`" << Constants::newline
+	          << "   -h | --help        show this help screen" << Constants::newline
+	          << "   -V                 show version" << Constants::newline
+	          << "  --version           show version and exit " << Constants::newline
+	          << Constants::newline;
 
 	return is_error ? 1 : 0;
 }
@@ -198,45 +173,124 @@ int Gas::run (int argc, char **argv)
 	return 0;
 }
 
+std::vector<option> Gas::common_options {
+	// Arguments ignored by GAS, we shall ignore them silently too
+	{ "divide",    no_argument,       nullptr, OPTION_IGNORE },
+	{ "k",         no_argument,       nullptr, OPTION_IGNORE },
+	{ "nocpp",     no_argument,       nullptr, OPTION_IGNORE },
+	{ "Qn",        no_argument,       nullptr, OPTION_IGNORE },
+	{ "Qy",        no_argument,       nullptr, OPTION_IGNORE },
+	{ "s",         no_argument,       nullptr, OPTION_IGNORE },
+	{ "w",         no_argument,       nullptr, OPTION_IGNORE },
+	{ "X",         no_argument,       nullptr, OPTION_IGNORE },
+
+	// Global GAS arguments we support
+	{ "o",         required_argument, nullptr, OPTION_O },
+	{ "warn",      no_argument,       nullptr, OPTION_WARN },
+	{ "g",         no_argument,       nullptr, OPTION_G },
+	{ "gen-debug", no_argument,       nullptr, OPTION_G },
+
+	// Arguments handled by us, not passed to llvm-mc
+	{ "h",         no_argument,       nullptr, OPTION_HELP },
+	{ "help",      no_argument,       nullptr, OPTION_HELP },
+	{ "V",         no_argument,       nullptr, OPTION_VERSION },
+	{ "version",   no_argument,       nullptr, OPTION_VERSION_EXIT },
+};
+
+std::vector<option> Gas::x86_options {
+	{ "32", no_argument, nullptr, OPTION_IGNORE }, // llvm-mc doesn't need this
+	{ "64", no_argument, nullptr, OPTION_IGNORE }, // llvm-mc doesn't need this
+};
+
+std::vector<option> Gas::arm32_options {
+	{ "mfpu", required_argument, nullptr, OPTION_MFPU },
+};
+
 Gas::ParseArgsResult Gas::parse_arguments (int argc, char **argv, std::unique_ptr<LlvmMcRunner>& mc_runner)
 {
-	cxxopts::Options options = create_options ();
+	std::vector<option> long_options { common_options };
+
+	switch (target_arch ()) {
+		case TargetArchitecture::ARM32:
+			long_options.insert (long_options.end (), arm32_options.begin (), arm32_options.end ());
+			break;
+
+		case TargetArchitecture::X86:
+		case TargetArchitecture::X64:
+			long_options.insert (long_options.end (), x86_options.begin (), x86_options.end ());
+			break;
+
+		default:
+			break;
+	}
+	long_options.push_back ({ nullptr, 0, nullptr, 0 });
+
+	constexpr char PROGRAM_DESCRIPTION[] = "Xamarin.Android GAS adapter for llvm-mc";
+
 	bool terminate = false, is_error = false;
-	bool show_version = false;
+	bool show_version = false, show_help = false;
 
-	options.parse_positional ("asmfile");
-	auto result = options.parse(argc, argv);
-	if (result.count ("help") > 0) {
-		exit (usage (false /* is_error */));
+	while (true) {
+		int opt_index = 0;
+		int c = getopt_long_only (argc, argv, "-", long_options.data (), &opt_index);
+
+		if (c == -1) {
+			break;
+		}
+
+		switch (c) {
+			case '?':
+				terminate = true;
+				is_error = true;
+				break;
+
+			case 1: // non-option argument
+			{
+				// Ignore the arch hack parameter
+				const char *ret = strstr (optarg, Constants::arch_hack_param);
+				if (ret == nullptr || ret != optarg) {
+					// char8_t* cast treats path string as utf8
+					input_files.emplace_back (reinterpret_cast<char8_t*>(optarg));
+				}
+			}
+			break;
+
+			case OPTION_VERSION:
+				show_version = true;
+				break;
+
+			case OPTION_VERSION_EXIT:
+				show_version = true;
+				terminate = true;
+				break;
+
+			case OPTION_HELP:
+				show_help = true;
+				terminate = true;
+				break;
+
+			case OPTION_O:
+				_gas_output_file = reinterpret_cast<char8_t*>(optarg);
+				break;
+
+			case OPTION_MFPU:
+				mc_runner->map_option ("mfpu", optarg);
+				break;
+
+			case OPTION_G:
+				mc_runner->generate_debug_info ();
+				break;
+		}
 	}
 
-	if (result.count ("version") > 0) {
-		show_version = true;
-		terminate = true;
-	}
-
-	if (result.count ("V") > 0) {
-		show_version = true;
-		terminate = false;
-	}
-
-	if (show_version) {
+	if (show_help) {
+		usage (false /* is_error */);
+		return {true, false};
+	} else if (show_version) {
 		std::cout << program_name () << " v" << XA_UTILS_VERSION << ", " << PROGRAM_DESCRIPTION << Constants::newline
 		          << "\tGAS version compatibility: " << BINUTILS_VERSION << Constants::newline
 		          << "\tllvm-mc version compatibility: " << LLVM_VERSION << Constants::newline << Constants::newline;
 		return {true, false};
-	}
-
-	if (result.count ("gen-debug") > 0) {
-		mc_runner->generate_debug_info ();
-	}
-
-	if (result.count ("mfpu") > 0) {
-		mc_runner->map_option ("mfpu", result["mfpu"].as<std::string> ());
-	}
-
-	if (result.count ("o") > 0) {
-		_gas_output_file = result["o"].as<std::string> ();
 	}
 
 	if (terminate) {
@@ -245,15 +299,6 @@ Gas::ParseArgsResult Gas::parse_arguments (int argc, char **argv, std::unique_pt
 
 	if (_gas_output_file.empty ()) {
 		_gas_output_file = Constants::default_output_name;
-	}
-
-	if (result.count ("asmfile") > 0) {
-		for (std::string const& asmfile : result["asmfile"].as<std::vector<std::string>> ()) {
-			// Ignore the arch hack parameter
-			if (!asmfile.starts_with (Constants::arch_hack_param)) {
-				input_files.emplace_back (asmfile);
-			}
-		}
 	}
 
  	return {terminate, is_error};

--- a/src/gas/gas.hh
+++ b/src/gas/gas.hh
@@ -2,20 +2,21 @@
 #if !defined (__GAS_HH)
 #define __GAS_HH
 
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+#include <getopt.h>
+
 #include <array>
 #include <filesystem>
+#include <iostream>
 #include <memory>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #if __has_include (<concepts>)
 #include <concepts>
 #endif // has <concepts>
-
-namespace cxxopts {
-	class Options;
-}
 
 namespace xamarin::android::gas
 {
@@ -137,8 +138,6 @@ namespace xamarin::android::gas
 
 	class Gas final
 	{
-		static inline constexpr std::string_view PROGRAM_DESCRIPTION { "Xamarin.Android GAS adapter for llvm-mc" };
-
 		struct ParseArgsResult
 		{
 			const bool terminate;
@@ -193,7 +192,6 @@ namespace xamarin::android::gas
 	private:
 		void determine_program_dir (int argc, char **argv);
 		int usage (bool is_error, std::string const message = "");
-		cxxopts::Options create_options ();
 
 	private:
 		static constexpr auto arm64_gas_name = concat_const (arm64_arch_prefix, generic_gas_name);
@@ -205,6 +203,10 @@ namespace xamarin::android::gas
 		static constexpr auto arm32_ld_name  = concat_const (arm32_arch_prefix, generic_ld_name);
 		static constexpr auto x86_ld_name    = concat_const (x86_arch_prefix, generic_ld_name);
 		static constexpr auto x64_ld_name    = concat_const (x64_arch_prefix, generic_ld_name);
+
+		static std::vector<option> common_options;
+		static std::vector<option> x86_options;
+		static std::vector<option> arm32_options;
 
 		std::vector<fs::path> input_files;
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android-binutils/pull/10
Context: https://github.com/xamarin/xamarin-android-binutils/commit/9d342d5057d39c0a9c48ce11cdea6694e36b71bc
Context: https://github.com/xamarin/xamarin-android/pull/8806#issuecomment-1995511357

Revert the portion of 9d342d5057 which modified the way command-line
arguments are parsed.  The `cxxopt` C++ library that was used turns out
not to support some GNU-style options (e.g. `-mfpu=vpf3`) which breaks
the MonoAOT compiler that uses them.

Instead, copy `getopt.c` (BSD 2-clause + MIT/X11 licenses) and
`getopt.h` (Public Domain license) implementations from the MinGW
project and use `getopt` across all platforms.

Additionally, fix generation of the artifact package by making sure that
all the executable files are, in fact, executable by setting the correct
permissions.