### PR TITLE
[ci] Use managed identity for API Scan

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -311,7 +311,10 @@ extends:
       jobs:
       - job: api_scan
         displayName: API Scan
-        pool: $(MicroBuildPoolName)
+        pool:
+          name: Maui-1ESPT
+          image: $(WindowsPoolImage1ESPT)
+          os: windows
         timeoutInMinutes: 360
         workspace:
           clean: all
@@ -347,7 +350,7 @@ extends:
             isLargeApp: true
             toolVersion: Latest
           env:
-            AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+            AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanMAUI1ESPTManagedId)
 
         - task: SdtReport@2
           displayName: Guardian Export - Security Report


### PR DESCRIPTION
I've configured a new [managed identity][0] (MSI) for API Scan, which
allows us to enable a more modern authentication approach when
running API Scan on the `MAUI-1ESPT` agent pool.

A new `$(ApiScanMAUI1ESPTManagedId)` variable has been configured in
the pipeline settings to pass the app ID for this MSI to the
API Scan task.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourcegroups/1esobjects/providers/microsoft.managedidentity/userassignedidentities/maui1esptapiscanidentity/overview
