### PR TITLE
[ci] Build on Ubuntu 20.04 LTS

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -57,7 +57,7 @@ variables:
 - name: WindowsPoolImage1ESPT
   value: 1ESPT-Windows2022
 - name: LinuxPoolImage1ESPT
-  value: 1ESPT-Ubuntu22.04
+  value: 1ESPT-Ubuntu20.04
 - name: MicroBuildPoolName
   value: VSEngSS-MicroBuild2022-1ES
 

--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -121,14 +121,14 @@ extends:
 
         - script: ./build-llvm.sh
           env:
-            CC: gcc-13
-            CXX: g++-13
+            CC: gcc-10
+            CXX: g++-10
           displayName: Build LLVM
 
         - script: ./build-xa-utils.sh
           env:
-            CC: gcc-13
-            CXX: g++-13
+            CC: gcc-10
+            CXX: g++-10
           displayName: Build utilities
 
         - script: |


### PR DESCRIPTION
.NET Android builds using binutils packages created on Ubuntu 22.04 have been failing on Ubuntu 20.04 with the followng:

    [llc stderr] /mnt/vss/_work/1/s/bin/Release/dotnet/packs/Microsoft.Android.Sdk.Linux/34.0.101/tools/Linux/binutils/bin/llc: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /mnt/vss/_work/1/s/bin/Release/dotnet/packs/Microsoft.Android.Sdk.Linux/34.0.101/tools/Linux/binutils/bin/llc) (TaskId:407)

Updates the Linux build to use the oldest still supported Ubuntu LTS to improve compatibility.