### PR TITLE
[ci] Use dynamic names for log artifacts

### DIFF
--- a/build-tools/automation/azure-pipelines.yml
+++ b/build-tools/automation/azure-pipelines.yml
@@ -96,7 +96,7 @@ extends:
           - output: pipelineArtifact
             displayName: Upload logs
             condition: always()
-            artifactName: build-logs-linux
+            artifactName: build-logs-linux-$(System.JobAttempt)
             targetPath: $(Build.StagingDirectory)
             sbomEnabled: false
           - output: pipelineArtifact
@@ -153,7 +153,7 @@ extends:
           - output: pipelineArtifact
             displayName: Upload logs
             condition: always()
-            artifactName: build-logs-macos
+            artifactName: build-logs-macos-$(System.JobAttempt)
             targetPath: $(Build.StagingDirectory)
             sbomEnabled: false
           - output: pipelineArtifact


### PR DESCRIPTION
Updates log artifact names to include the job attempt number.  This
should avoid job re-run failures that occur when attempting to upload a
log artifact that already exists.