### PR TITLE
[s360] Ignore irrelevant LLVM+Python warnings

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,15 @@
+paths:
+  exclude:
+    # we don't ship lldb
+    - external/llvm/lldb
+    # we don't ship clang docs
+    - external/llvm/clang/docs
+    # we don't ship tests
+    - external/llvm/compiler-rt/test
+    # we don't ship these either
+    - external/llvm/clang/tools
+    - external/llvm/llvm/tools
+    - external/llvm/llvm/utils/
+    - external/llvm/clang/utils/CaptureCmd # not used by anything?!
+    # we don't ship "rando" tools either
+    - external/llvm/llvm/tools


### PR DESCRIPTION
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051172
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051182
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051183
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051185
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051188
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051189
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051199
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051208
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051210
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051213
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051217
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051218
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051219
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051220
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051221

Ignore irrelevant S360 warnings.  They're irrelevant because the warnings involve code which is run as part of llvm unit tests, and/or are not used by or shipped with .NET for Android:

  * This part of the regular expression may cause exponential backtracking on strings starting with `#include lldb`` and containing many repetitions of `/`. in external/llvm/lldb/scripts/analyze-project-deps.py
  * Call to deprecated function tempfile.mktemp may be insecure. in external/llvm/lldb/examples/python/gdbremote.py
  * Call to deprecated function tempfile.mktemp may be insecure. in external/llvm/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
  * This part of the regular expression may cause exponential backtracking on strings starting with `enum\t0:` and containing many repetitions of `0`. in external/llvm/clang/docs/tools/dump_format_style.py
  * Call to deprecated function tempfile.mktemp may be insecure. in external/llvm/compiler-rt/test/sanitizer_common/android_commands/android_common.py
  * This part of the regular expression may cause exponential backtracking on strings starting with `label= \t%tmpa` and containing many repetitions of `0`. in external/llvm/llvm/utils/DSAclean.py
  * Use of unapproved hash algorithm or API SHA1. in external/llvm/clang/utils/CaptureCmd
  * Call to deprecated function tempfile.mktemp may be insecure. in external/llvm/lldb/examples/python/delta.py
  * This path depends on a [user-provided value](1). in external/llvm/llvm/tools/sancov/coverage-report-server.py
  * This part of the regular expression may cause exponential backtracking on strings starting with `{{{{` and containing many repetitions of `a}}}}{{{{`. in external/llvm/llvm/utils/lit/lit/BooleanExpression.py
  * Use of unapproved hash algorithm or API SHA1. in external/llvm/libcxx/utils/adb_run.py
  * This part of the regular expression may cause exponential backtracking on strings containing many repetitions of `+`. in external/llvm/llvm/utils/lit/lit/BooleanExpression.py
  * Use of unapproved hash algorithm or API MD5. in external/llvm/lldb/utils/lldb-repro/lldb-repro.py
  * This part of the regular expression may cause exponential backtracking on strings containing many repetitions of `/`. in external/llvm/clang/tools/scan-build-py/tests/unit/test_report.py
  * This part of the regular expression may cause exponential backtracking on strings containing many repetitions of `/`. in external/llvm/clang/tools/scan-build-py/tests/unit/test_analyze.py